### PR TITLE
fix issue 19 android start foreground service

### DIFF
--- a/android/src/main/java/com/ingageco/capacitormusiccontrols/MusicControlsNotificationKiller.java
+++ b/android/src/main/java/com/ingageco/capacitormusiccontrols/MusicControlsNotificationKiller.java
@@ -1,5 +1,6 @@
 package com.ingageco.capacitormusiccontrols;
 
+import android.app.Activity;
 import android.app.Notification;
 import android.app.Service;
 import android.os.Build;
@@ -9,13 +10,13 @@ import android.app.NotificationManager;
 import android.content.Intent;
 import android.util.Log;
 
-
 public class MusicControlsNotificationKiller extends Service {
 	private static final String TAG = "MusicControlsNotificationKiller";
 
 	private static int NOTIFICATION_ID;
 	private NotificationManager mNM;
 	private final IBinder mBinder = new KillBinder(this);
+	private boolean isRunning = false;
 
 	@Override
 	public IBinder onBind(Intent intent) {
@@ -46,6 +47,7 @@ public class MusicControlsNotificationKiller extends Service {
 
 		mNM = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
 		mNM.cancel(NOTIFICATION_ID);
+		this.isRunning = false;
 	}
 
 	@Override
@@ -56,9 +58,15 @@ public class MusicControlsNotificationKiller extends Service {
 		mNM.cancel(NOTIFICATION_ID);
 	}
 
-	public void setForeground(Notification notification) {
+	public void setForeground(Notification notification, Activity activity) {
 
 		Log.i(TAG, "setForeground");
+
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && !this.isRunning) {
+            Log.i(TAG, "startForegroundService");
+            this.isRunning = true;
+            this.startForegroundService(new Intent(activity, MusicControlsNotificationKiller.class));
+        }
 
 		this.startForeground(this.NOTIFICATION_ID, notification);
 	}

--- a/android/src/main/java/com/ingageco/capacitormusiccontrols/MusicControlsServiceConnection.java
+++ b/android/src/main/java/com/ingageco/capacitormusiccontrols/MusicControlsServiceConnection.java
@@ -26,11 +26,8 @@ public class MusicControlsServiceConnection implements ServiceConnection {
         Log.i(TAG, "onServiceConnected");
 
         this.service = ((KillBinder) binder).service;
-       // this.service.startService(new Intent(activity, MusicControlsNotificationKiller.class));
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            this.service.startForegroundService(new Intent(activity, MusicControlsNotificationKiller.class));
-        } else {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
             this.service.startService(new Intent(activity, MusicControlsNotificationKiller.class));
         }
     }
@@ -48,7 +45,7 @@ public class MusicControlsServiceConnection implements ServiceConnection {
         Log.i(TAG, "setNotification");
 
         if (isPlaying) {
-            this.service.setForeground(notification);
+            this.service.setForeground(notification, this.activity);
         } else {
             this.service.clearForeground();
         }


### PR DESCRIPTION
Move startForegroundService() into notification killer to avoid Google Play flagging as an error that startForeground() did not get called in time:  https://github.com/ingageco/capacitor-music-controls-plugin/issues/19